### PR TITLE
feat: implement local service cache with dynamic updates

### DIFF
--- a/src/main/java/Client/TestClient.java
+++ b/src/main/java/Client/TestClient.java
@@ -5,7 +5,7 @@ import common.pojo.User;
 import common.service.UserService;
 
 public class TestClient {
-    public static void main(String[] args) {
+    public static void main(String[] args) throws InterruptedException {
         // Outdated  way to initialize ClientProxy with a specific server address and port
         // ClientProxy clientProxy = new ClientProxy("127.0.0.1", 9999);
 

--- a/src/main/java/Client/cache/ServiceCache.java
+++ b/src/main/java/Client/cache/ServiceCache.java
@@ -1,0 +1,79 @@
+package Client.cache;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class ServiceCache {
+    // Stores service names and their corresponding address lists
+    private static Map<String, List<String>> cache = new HashMap<>();
+
+    /**
+     * Adds a service and its address to the local cache.
+     *
+     * @param serviceName The name of the service.
+     * @param address The address of the service instance.
+     */
+    public void addServiceToCache(String serviceName, String address) {
+        if (!cache.containsKey(serviceName)) {
+            List<String> addressList = cache.get(serviceName);
+            addressList.add(address);
+            System.out.println("Service " + serviceName + " with address of " + address +" added to the localcache");
+        } else {
+            List<String> addressList = new ArrayList<>();
+            addressList.add(address);
+            cache.put(serviceName, addressList);
+        }
+        System.out.println("Service " + serviceName + " with address of " + address +" added to the local cache");
+    }
+
+    /**
+     * Replaces an old service address with a new one in the cache.
+     *
+     * @param serviceName The name of the service.
+     * @param oldAddress The existing address to be replaced.
+     * @param newAddress The new address to be added.
+     */
+    public void replaceServiceAddress(String serviceName, String oldAddress, String newAddress) {
+        if (!cache.containsKey(serviceName)) {
+            List<String> addressList = cache.get(serviceName);
+            addressList.remove(oldAddress);
+            addressList.add(newAddress);
+        } else {
+            System.out.println("Update failed: Service does not exist.");
+        }
+    }
+
+    /**
+     * Retrieves a list of service addresses from the cache.
+     *
+     * @param serviceName The name of the service.
+     * @return A list of service addresses, or null if the service is not found.
+     */
+    public List<String> getServiceFromCache(String serviceName) {
+        if (!cache.containsKey(serviceName)) return null;
+        return cache.get(serviceName);
+    }
+
+
+    /**
+     * Removes a service address from the local cache.
+     *
+     * @param serviceName The name of the service.
+     * @param address The address to be removed.
+     */
+    public void removeServiceAddress(String serviceName, String address) {
+        if (cache.containsKey(serviceName)) {
+            List<String> addressList = cache.get(serviceName);
+            if (addressList.contains(address)) {
+                addressList.remove(address);
+                System.out.println("Removed service: " + serviceName + " with address: " + address + " from the local cache.");
+            } else {
+                System.out.println("Remove Failed: Service address doesn't exist.");
+            }
+        } else {
+            System.out.println("Remove Failed: Service name doesn't exist.");
+        }
+    }
+}

--- a/src/main/java/Client/proxy/ClientProxy.java
+++ b/src/main/java/Client/proxy/ClientProxy.java
@@ -28,7 +28,7 @@ public class ClientProxy implements InvocationHandler {
 //        }
 //    }
 
-    public ClientProxy() {
+    public ClientProxy() throws InterruptedException {
         rpcClient = new NettyRPCClient();
     }
 

--- a/src/main/java/Client/rpcClient/impl/NettyRPCClient.java
+++ b/src/main/java/Client/rpcClient/impl/NettyRPCClient.java
@@ -21,7 +21,7 @@ public class NettyRPCClient implements RPCClient {
     private static final EventLoopGroup eventLoopGroup;
     private ServiceCentre serviceCentre;
 
-    public NettyRPCClient() {
+    public NettyRPCClient() throws InterruptedException {
         this.serviceCentre = new ZKServiceCentre();
     }
 

--- a/src/main/java/Client/serviceCentre/watcher/ZKwatcher.java
+++ b/src/main/java/Client/serviceCentre/watcher/ZKwatcher.java
@@ -1,0 +1,100 @@
+package Client.serviceCentre.watcher;
+
+import Client.cache.ServiceCache;
+import org.apache.curator.framework.CuratorFramework;
+import org.apache.curator.framework.recipes.cache.ChildData;
+import org.apache.curator.framework.recipes.cache.CuratorCache;
+import org.apache.curator.framework.recipes.cache.CuratorCacheListener;
+
+import java.util.Arrays;
+
+public class ZKwatcher {
+    // Zookeeper client
+    private final CuratorFramework client;
+    // Local service cache
+    private final ServiceCache serviceCache;
+
+    /**
+     * Constructor to initialize the Zookeeper watcher.
+     *
+     * @param client The Zookeeper client.
+     * @param serviceCache The local cache for storing and managing service addresses.
+     */
+    public ZKwatcher(CuratorFramework client, ServiceCache serviceCache) {
+        this.client = client;
+        this.serviceCache = serviceCache;
+    }
+
+    /**
+     * Watches for updates to the specified Zookeeper node.
+     * This method listens for changes such as node creation, updates, and deletions.
+     *
+     * @param path The path of the Zookeeper node to watch.
+     * @throws InterruptedException If the thread is interrupted while setting up the watcher.
+     */
+    public void watchToUpdate(String path) throws InterruptedException {
+        // Used to monitor node changes under the specified path and update the local cache when changes occur.
+        // CuratorCache is an API provided by Curator for conveniently monitoring node changes.
+        // It listens for changes in the specified path, and in this case, it is monitoring the root path.
+        CuratorCache curatorCache = CuratorCache.build(client, "/");
+        // Registers a listener to handle node events such as creation, update, and deletion
+        curatorCache.listenable().addListener(new CuratorCacheListener() {
+
+            /**
+             * Handles node events and updates the local cache accordingly.
+             *
+             * @param type       The event type (`NODE_CREATED`, `NODE_CHANGED`, `NODE_DELETED`).
+             * @param childData  The previous data of the node (null for `NODE_CREATED`).
+             * @param childData1 The updated data of the node (null for `NODE_DELETED`).
+             */
+            @Override
+            public void event(Type type, ChildData childData, ChildData childData1) {
+                switch (type.name()) {
+                    // When the watcher is first established, it may detect pre-existing nodes and trigger this event
+                    case "NODE_CREATED":
+                        String[] pathArray = parsePath(childData1);
+                        if (pathArray.length > 2) {
+                            String serviceName = pathArray[1];
+                            String address = pathArray[2];
+                            serviceCache.addServiceToCache(serviceName, address);
+                        }
+                        break;
+                    case "NODE_CHANGE":
+                        if (childData.getData() != null) {
+                            System.out.println("Previous Data: " + Arrays.toString(childData.getData()));
+                        } else {
+                            System.out.println("No Previous Data exists");
+                        }
+                        String[] oldPathArray = parsePath(childData);
+                        String[] newPathArray = parsePath(childData1);
+                        serviceCache.replaceServiceAddress(oldPathArray[1], oldPathArray[2], newPathArray[2]);
+                        System.out.println("Updated Data: " + Arrays.toString(childData1.getData()));
+                        break;
+                    case "NODE_DELETED":
+                        String[] deletedPathArray = parsePath(childData);
+                        if (deletedPathArray.length > 2) {
+                            String serviceName = deletedPathArray[1];
+                            String address = deletedPathArray[2];
+                            serviceCache.removeServiceAddress(serviceName, address);
+                        }
+                        break;
+                    default:
+                        break;
+                }
+            }
+        });
+        // Starts listening for events
+        curatorCache.start();
+    }
+
+    /**
+     * Parses the full path of a node and extracts its components.
+     *
+     * @param childData The node data containing the path.
+     * @return An array of path components split by "/".
+     */
+    private String[] parsePath(ChildData childData) {
+        String path = new String(childData.getData());
+        return path.split("/");
+    }
+}


### PR DESCRIPTION
- Added a local service cache on the client side
- Implemented dynamic updates to keep the cache in sync with the service registry
- Improved service discovery efficiency by reducing ZooKeeper queries